### PR TITLE
空の execute-method で実行可能なように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,59 @@
 # unity-command-github-action
 
-This action executes the Unity command line.
+![Build][0]
+
+This action is for executing a specific build script.
 For more information about the Unity command line, please refer to the [official documentation][1].
+
+This action also automatically generates a build script that does nothing but open the Unity project if an empty string is passed to `execute-method`.
+This can only be used to check for compile errors.
 
 ## Usage
 
 ### Simple usage
 
+In the following call to action, the program simply opens the project in iOS without passing any particular parameters.
+This process will compile with the target set to iOS in Unity.
+
 ```yml
 - uses: akiojin/unity-command-github-action@v1
   with:
-    build-target: 'iOS'
+    build-target: iOS
 ```
 
 ### Additional arguments
 
+The following call to action calls the program `UnityBuildScript.PerformBuild` in the build script.
+The parameter `-v --param="Test"` is passed when executing that build script.
+
 ```yml
 - uses: akiojin/unity-command-github-action@v1
   with:
-    build-target: 'iOS'
+    build-target: iOS
     project-directory: ${{ github.workspace }}
-    additional-arguments: '-v --param="Test"'
+    execute-method: UnityBuildScript.PerformBuild
+    additional-arguments: -v --param="Test"
 ```
 
 ## Arguments
 
 ### Common
 
-| Name                 | Required | Type     | Default           | Description                                                                                                                                                                                                                                                               |
-| -------------------- | -------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| additional-arguments | `false`  | `string` | ""                | Specify additional required arguments.                                                                                                                                                                                                                                    |
-| build-target         | `true`   | `string` |                   | Allows the selection of an active build target before loading a project.<br><br>Possible options are:<br>Standalone, Win, Win64, OSXUniversal, Linux, Linux64, LinuxUniversal, iOS, Android, Web, WebStreamed, WebGL, XboxOne, PS4, WindowsStoreApps, Switch, N3DS, tvOS. |
-| execute-method       | `false`  | `string` | ""                | Execute the static method as soon as Unity opens the project, and after the optional Asset server update is complete.                                                                                                                                                     |
-| log-file             | `false`  | `string` | `"-"`             | Specify where Unity writes the Editor or Windows/Linux/OSX standalone log file.<br>To output to the console, specify "-" for the path name.<br>On Windows, specify - option to make the output go to stdout, which is not the console by default.                         |
-| project-directory    | `false`  | `string` | $GITHUB_WORKSPACE | Open the project at the given path.                                                                                                                                                                                                                                       |
-| unity-version        | `false`  | `string` | ""                | Specify the Unity version to be used.<br>If omitted, the project version is used.                                                                                                                                                                                         |
+| Name                   | Required | Type     | Default           | Description                                                                                                                                                                                                                                                               |
+| ---------------------- | -------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `additional-arguments` | `false`  | `string` | `""`              | Specify additional required arguments.                                                                                                                                                                                                                                    |
+| `build-target`         | `true`   | `string` |                   | Allows the selection of an active build target before loading a project.<br><br>Possible options are:<br>Standalone, Win, Win64, OSXUniversal, Linux, Linux64, LinuxUniversal, iOS, Android, Web, WebStreamed, WebGL, XboxOne, PS4, WindowsStoreApps, Switch, N3DS, tvOS. |
+| `execute-method`       | `false`  | `string` |                   | Execute the static method as soon as Unity opens the project, and after the optional Asset server update is complete.                                                                                                                                                     |
+| `install-directory`    | `false`  | `string` | `""`              | If the Unity installation location is not the default, specify the path in this parameter.<br>The path must exclude the version number.<br>ex) E:\Unity\                                                                                                                  |
+| `log-file`             | `false`  | `string` | `"-"`             | Specify where Unity writes the Editor or Windows/Linux/OSX standalone log file.<br>To output to the console, specify "-" for the path name.<br>On Windows, specify - option to make the output go to stdout, which is not the console by default.                         |
+| `project-directory`    | `false`  | `string` | $GITHUB_WORKSPACE | Open the project at the given path.                                                                                                                                                                                                                                       |
+| `unity-version`        | `false`  | `string` | `""`              | Specify the Unity version to be used.<br>If omitted, the project version is used.                                                                                                                                                                                         |
 
 ## License
 
 Any contributions made under this project will be governed by the [MIT License][3].
 
-[0]: https://github.com/akiojin/unity-command-github-action/actions/workflows/Test.yml/badge.svg
-[1]: https://docs.unity3d.com/2021.2/Documentation/Manual/EditorCommandLineArguments.html
+[0]: https://github.com/akiojin/unity-command-github-action/actions/workflows/Build.yml/badge.svg
+[1]: https://docs.unity3d.com/2022.3/Documentation/Manual/EditorCommandLineArguments.html
 [2]: https://github.com/akiojin/unity-command-github-action/blob/main/action.yml
 [3]: https://github.com/akiojin/unity-command-github-action/blob/main/LICENSE

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,6 @@ inputs:
       Specify additional required arguments.
       Arguments are specified with a space between them.
     required: false
-    default: ''
   build-target:
     description: >
       Allows the selection of an active build target before loading a project.
@@ -18,14 +17,13 @@ inputs:
     description: >
       Execute the static method as soon as Unity opens the project,
       and after the optional Asset server update is complete.
-    required: true
+    required: false
   install-directory:
     description: >
       If the Unity installation location is not the default, specify the path in this parameter.
       The path must exclude the version number.
       ex) E:\Unity\
     required: false
-    default: ''
   log-file:
     description: >
       Specify where Unity writes the Editor or Windows/Linux/OSX standalone log file.

--- a/src/UnityBuildScriptHelper.ts
+++ b/src/UnityBuildScriptHelper.ts
@@ -1,0 +1,17 @@
+export default class UnityBuildScriptHelper
+{
+    static GenerateUnityBuildScript()
+    {
+        return `namespace unity_command_github_action
+{
+    using UnityEditor;
+    using UnityEngine;
+
+    public class UnityBuildScript
+    {
+        static void OpenProject()
+            => EditorApplication.Exit(0);
+    }
+}`;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,26 +1,59 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
+import * as fs from 'fs/promises'
+import path from 'path'
 import { UnityUtils, UnityCommandBuilder } from '@akiojin/unity-command'
+import UnityBuildScriptHelper from './UnityBuildScriptHelper'
+
+async function GenerateUnityBuildScript(): Promise<void>
+{
+    const script = UnityBuildScriptHelper.GenerateUnityBuildScript()
+    const buildScriptName = 'UnityBuildScript.cs'
+    const cs = path.join(core.getInput('project-directory'), 'Assets', 'Editor', buildScriptName)
+
+    await fs.mkdir(path.dirname(cs), {recursive: true})
+    await fs.writeFile(cs, script)
+
+    core.startGroup(`Generate "${buildScriptName}"`)
+    core.info(`${buildScriptName}:\n${script}`)
+    core.endGroup()
+}
+
+async function Execute(executeMethod: string): Promise<void>
+{
+    const builder = new UnityCommandBuilder()
+        .SetBuildTarget(UnityUtils.GetBuildTarget())
+        .SetProjectPath(core.getInput('project-directory'))
+		.SetExecuteMethod(executeMethod)
+        .SetLogFile(core.getInput('log-file'))
+        .EnablePackageManagerTraces()
+
+    if (!!core.getInput('additional-arguments')) {
+        builder.Append(core.getInput('additional-arguments'))
+    }
+
+    const version = core.getInput('unity-version') ||
+        await UnityUtils.GetCurrentUnityVersion(core.getInput('project-directory'))
+
+    core.startGroup('Run Unity')
+    await exec.exec(UnityUtils.GetUnityPath(version, core.getInput('install-directory')), builder.Build())
+    core.endGroup()
+}
+
+async function GetExecuteMethod(): Promise<string>
+{
+	if (!core.getInput('execute-method')) {
+		await GenerateUnityBuildScript()
+		return 'unity_command_github_action.UnityBuildScript.OpenProject'
+	} else {
+		return core.getInput('execute-method')
+	}
+}
 
 async function Run()
 {
 	try {
-		const builder = new UnityCommandBuilder()
-			.SetBuildTarget(UnityUtils.GetBuildTarget())
-			.SetProjectPath(core.getInput('project-directory'))
-			.SetExecuteMethod(core.getInput('execute-method'))
-			.SetLogFile(core.getInput('log-file'))
-
-		if (!!core.getInput('additional-arguments')) {
-			builder.Append(core.getInput('additional-arguments').split(' '))
-		}
-	
-		const version = core.getInput('unity-version') ||
-			await UnityUtils.GetCurrentUnityVersion(core.getInput('project-directory'))
-
-		core.startGroup('Run Unity')
-		await exec.exec(UnityUtils.GetUnityPath(version, core.getInput('install-directory')), builder.Build())
-		core.endGroup()
+		await Execute(await GetExecuteMethod())
 	} catch (ex: any) {
 		core.setFailed(ex.message)
 	}


### PR DESCRIPTION
- execute-method に空文字が渡された場合に、Unityプロジェクトを開くただけのスクリプトを生成して、それを実行するように変更